### PR TITLE
Release v1.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# GitHub Dependabot Configuration
+#
+# Dependabot can maintain your repository's dependencies automatically.
+#
+# Documentation:
+# - https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+# - https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically
+
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore:"
+    labels:
+      - dependencies
+    open-pull-requests-limit: 5

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,25 @@
 # History
 
+## 1.1.0 (2022-05-06)
+
+- (PR #19, 2022-01-24) chore(deps-dev): Bump ipython from 7.28.0 to 7.31.1
+- (PR #21, 2022-01-24) chore(deps): Bump django from 3.2.8 to 3.2.11
+- (PR #22, 2022-02-03) chore: Add Dependabot configuration
+- (PR #26, 2022-02-03) chore: bump black from 21.9b0 to 22.1.0
+- (PR #25, 2022-02-03) chore: bump djangorestframework from 3.12.4 to 3.13.1
+- (PR #27, 2022-02-03) chore: bump unittest-xml-reporting from 3.0.4 to 3.2.0
+- (PR #23, 2022-02-03) chore: bump isort from 5.8.0 to 5.10.1
+- (PR #30, 2022-02-03) chore: bump flake8 from 3.9.2 to 4.0.1
+- (PR #29, 2022-02-03) chore: bump mypy from 0.910 to 0.931
+- (PR #31, 2022-03-24) chore: bump django from 3.2.11 to 3.2.12
+- (PR #32, 2022-03-24) chore: bump coverage from 6.0 to 6.3.2
+- (PR #37, 2022-03-24) chore: bump mypy from 0.931 to 0.942
+- (PR #41, 2022-05-04) chore: bump django from 3.2.12 to 3.2.13
+- (PR #39, 2022-05-04) chore: bump black from 22.1.0 to 22.3.0
+- (PR #42, 2022-05-05) chore: bump mypy from 0.942 to 0.950
+- (PR #40, 2022-05-06) feat: Add pagination data to response schema
+- (PR #43, 2022-05-06) chore: bump ipython from 7.31.1 to 8.3.0
+
 ## 1.0.1 (2021-12-02)
 
 - (PR #14, 2021-10-19) chore: Fix file permissions

--- a/fyntex/__init__.py
+++ b/fyntex/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore[has-type]
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/fyntex/drf_pagination_utils/styles.py
+++ b/fyntex/drf_pagination_utils/styles.py
@@ -85,6 +85,134 @@ class LinkHeaderPageNumberPagination(rest_framework.pagination.PageNumberPaginat
         """
         return schema
 
+    def get_paginated_components_schemas(
+        self, components: Mapping[str, Mapping[str, object]]
+    ) -> Mapping[str, Mapping[str, object]]:
+        """
+        Return schema for pagination-related components.
+
+        .. seealso::
+          https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.2.md#components-object
+
+        :param components: OpenAPI ``Components`` object.
+        :return: Updated OpenAPI ``Components`` object.
+        """
+        if hasattr(super(), 'get_paginated_components_schemas'):
+            components = super().get_paginated_components_schemas(components)
+
+        component_name = 'headers'
+        content = {
+            'Link': {
+                'description': 'Web Links (RFC 8288)',
+                'schema': {'type': 'string'},
+                'examples': {
+                    'pagination': {
+                        'summary': """Link Header Page Number Pagination.
+
+A simple page number–based style that supports page numbers as query parameters
+and includes pagination links in an RFC 8288–compliant `Link` header.""",
+                        'value': ', '.join(
+                            (
+                                '<http://www.example.com/example-items/>; rel="first"',
+                                '<http://www.example.com/example-items/?page=3>; rel="previous"',
+                                '<http://www.example.com/example-items/?page=5>; rel="next"',
+                                '<http://www.example.com/example-items/?page=42>; rel="last"',
+                            )
+                        ),
+                    },
+                },
+            },
+        }
+        components = {
+            component_name: {},
+            **components,
+        }
+        components[component_name] = {
+            **components[component_name],
+            **content,
+        }
+
+        component_name = 'links'
+        content = {
+            'collection_first_page': {
+                'description': """First page of the collection of items.
+
+Use the URL returned in the relation type `first` of the response `Link` header.""",
+            },
+            'collection_previous_page': {
+                'description': """Previous page of the collection of items.
+
+Use the URL returned in the relation type `previous` of the response `Link` header.""",
+            },
+            'collection_next_page': {
+                'description': """Next page of the collection of items.
+
+Use the URL returned in the relation type `next` of the response `Link` header.""",
+            },
+            'collection_last_page': {
+                'description': """Last page of the collection of items.
+
+Use the URL returned in the relation type `last` of the response `Link` header.""",
+            },
+        }
+        components = {
+            component_name: {},
+            **components,
+        }
+        components[component_name] = {
+            **components[component_name],
+            **content,
+        }
+
+        return components
+
+    def get_paginated_response_headers_schema(
+        self, response_headers: Mapping[str, Mapping[str, object]]
+    ) -> Mapping[str, Mapping[str, object]]:
+        """
+        Return schema for headers of paginated responses.
+
+        .. seealso::
+          https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.2.md#response-object
+
+        :param response_headers: Field ``headers`` of OpenAPI ``Response`` object.
+        :return: Updated field ``headers`` of OpenAPI ``Response`` object.
+        """
+        if hasattr(super(), 'get_paginated_response_headers_schema'):
+            response_headers = super().get_paginated_response_headers_schema(response_headers)
+
+        response_headers = {
+            **response_headers,
+            'Link': {
+                '$ref': '#/components/headers/Link',
+            },
+        }
+        return response_headers
+
+    def get_paginated_response_links_schema(
+        self, response_links: Mapping[str, Mapping[str, object]]
+    ) -> Mapping[str, Mapping[str, object]]:
+        """
+        Return schema for links of paginated responses.
+
+        .. seealso::
+          https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.2.md#response-object
+
+        :param response_links: Field ``links`` of OpenAPI ``Response`` object.
+        :return: Updated field ``links`` of OpenAPI ``Response`` object.
+        """
+        if hasattr(super(), 'get_paginated_response_links_schema'):
+            response_links = super().get_paginated_response_links_schema(response_links)
+
+        response_links = {
+            **response_links,
+            'first_page': {'$ref': '#/components/links/collection_first_page'},
+            'previous_page': {'$ref': '#/components/links/collection_previous_page'},
+            'next_page': {'$ref': '#/components/links/collection_next_page'},
+            'last_page': {'$ref': '#/components/links/collection_last_page'},
+        }
+        return response_links
+
 
 class ObjectCountHeaderPageNumberPagination(rest_framework.pagination.PageNumberPagination):
     """
@@ -124,3 +252,63 @@ class ObjectCountHeaderPageNumberPagination(rest_framework.pagination.PageNumber
         :return: Paginated response schema.
         """
         return schema
+
+    def get_paginated_components_schemas(
+        self, components: Mapping[str, Mapping[str, object]]
+    ) -> Mapping[str, Mapping[str, object]]:
+        """
+        Return schema for pagination-related components.
+
+        .. seealso::
+          https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.2.md#components-object
+
+        :param components: OpenAPI ``Components`` object.
+        :return: Updated OpenAPI ``Components`` object.
+        """
+        if hasattr(super(), 'get_paginated_components_schemas'):
+            components = super().get_paginated_components_schemas(components)
+
+        if self.object_count_header:
+            component_name = 'headers'
+            content = {
+                self.object_count_header: {
+                    'description': """Total number of items in the collection.
+
+Note: Header is optional for single-page responses.""",
+                    'schema': {'type': 'integer'},
+                },
+            }
+            components = {
+                component_name: {},
+                **components,
+            }
+            components[component_name] = {
+                **components[component_name],
+                **content,
+            }
+
+        return components
+
+    def get_paginated_response_headers_schema(
+        self, response_headers: Mapping[str, Mapping[str, object]]
+    ) -> Mapping[str, Mapping[str, object]]:
+        """
+        Return schema for headers of paginated responses.
+
+        .. seealso::
+          https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.2.md#response-object
+
+        :param response_headers: Field ``headers`` of OpenAPI ``Response`` object.
+        :return: Updated field ``headers`` of OpenAPI ``Response`` object.
+        """
+        if hasattr(super(), 'get_paginated_response_headers_schema'):
+            response_headers = super().get_paginated_response_headers_schema(response_headers)
+
+        if self.object_count_header:
+            response_headers = {
+                **response_headers,
+                self.object_count_header: {
+                    '$ref': f'#/components/headers/{self.object_count_header}',
+                },
+            }
+        return response_headers

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,7 +4,7 @@
 
 -c requirements.txt
 
-black==21.9b0
+black==22.1.0
 coverage==6.0
 flake8-formatter-junit-xml==0.0.6
 flake8==3.9.2

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -10,5 +10,5 @@ flake8-formatter-junit-xml==0.0.6
 flake8==4.0.1
 ipython==7.31.1
 isort==5.10.1
-mypy==0.910
+mypy==0.931
 unittest-xml-reporting==3.2.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,7 +8,7 @@ black==22.3.0
 coverage==6.3.2
 flake8-formatter-junit-xml==0.0.6
 flake8==4.0.1
-ipython==7.31.1
+ipython==8.3.0
 isort==5.10.1
 mypy==0.950
 unittest-xml-reporting==3.2.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -9,6 +9,6 @@ coverage==6.0
 flake8-formatter-junit-xml==0.0.6
 flake8==3.9.2
 ipython==7.31.1
-isort==5.8.0
+isort==5.10.1
 mypy==0.910
 unittest-xml-reporting==3.2.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -7,7 +7,7 @@
 black==22.1.0
 coverage==6.0
 flake8-formatter-junit-xml==0.0.6
-flake8==3.9.2
+flake8==4.0.1
 ipython==7.31.1
 isort==5.10.1
 mypy==0.910

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,7 +8,7 @@ black==21.9b0
 coverage==6.0
 flake8-formatter-junit-xml==0.0.6
 flake8==3.9.2
-ipython==7.28.0
+ipython==7.31.1
 isort==5.8.0
 mypy==0.910
 unittest-xml-reporting==3.0.4

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -10,5 +10,5 @@ flake8-formatter-junit-xml==0.0.6
 flake8==4.0.1
 ipython==7.31.1
 isort==5.10.1
-mypy==0.931
+mypy==0.942
 unittest-xml-reporting==3.2.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,7 +5,7 @@
 -c requirements.txt
 
 black==22.1.0
-coverage==6.0
+coverage==6.3.2
 flake8-formatter-junit-xml==0.0.6
 flake8==4.0.1
 ipython==7.31.1

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -11,4 +11,4 @@ flake8==3.9.2
 ipython==7.31.1
 isort==5.8.0
 mypy==0.910
-unittest-xml-reporting==3.0.4
+unittest-xml-reporting==3.2.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,7 +4,7 @@
 
 -c requirements.txt
 
-black==22.1.0
+black==22.3.0
 coverage==6.3.2
 flake8-formatter-junit-xml==0.0.6
 flake8==4.0.1

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -10,5 +10,5 @@ flake8-formatter-junit-xml==0.0.6
 flake8==4.0.1
 ipython==7.31.1
 isort==5.10.1
-mypy==0.942
+mypy==0.950
 unittest-xml-reporting==3.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ coverage==6.0
     # via -r requirements-dev.in
 decorator==5.1.0
     # via ipython
-flake8==3.9.2
+flake8==4.0.1
     # via
     #   -r requirements-dev.in
     #   flake8-formatter-junit-xml
@@ -54,9 +54,9 @@ prompt-toolkit==3.0.20
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via flake8
-pyflakes==2.3.1
+pyflakes==2.4.0
     # via flake8
 pygments==2.10.0
     # via ipython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ black==22.1.0
     # via -r requirements-dev.in
 click==8.0.1
     # via black
-coverage==6.0
+coverage==6.3.2
     # via -r requirements-dev.in
 decorator==5.1.0
     # via ipython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 backcall==0.2.0
     # via ipython
-black==22.1.0
+black==22.3.0
     # via -r requirements-dev.in
 click==8.0.1
     # via black

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ flake8==3.9.2
     #   flake8-formatter-junit-xml
 flake8-formatter-junit-xml==0.0.6
     # via -r requirements-dev.in
-ipython==7.28.0
+ipython==7.31.1
     # via -r requirements-dev.in
 isort==5.8.0
     # via -r requirements-dev.in

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,7 +34,7 @@ matplotlib-inline==0.1.3
     # via ipython
 mccabe==0.6.1
     # via flake8
-mypy==0.931
+mypy==0.942
     # via -r requirements-dev.in
 mypy-extensions==0.4.3
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,7 +34,7 @@ matplotlib-inline==0.1.3
     # via ipython
 mccabe==0.6.1
     # via flake8
-mypy==0.942
+mypy==0.950
     # via -r requirements-dev.in
 mypy-extensions==0.4.3
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements-dev.in
 #
+asttokens==2.0.5
+    # via stack-data
 backcall==0.2.0
     # via ipython
 black==22.3.0
@@ -14,13 +16,15 @@ coverage==6.3.2
     # via -r requirements-dev.in
 decorator==5.1.0
     # via ipython
+executing==0.8.3
+    # via stack-data
 flake8==4.0.1
     # via
     #   -r requirements-dev.in
     #   flake8-formatter-junit-xml
 flake8-formatter-junit-xml==0.0.6
     # via -r requirements-dev.in
-ipython==7.31.1
+ipython==8.3.0
     # via -r requirements-dev.in
 isort==5.10.1
     # via -r requirements-dev.in
@@ -54,6 +58,8 @@ prompt-toolkit==3.0.20
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
+pure-eval==0.2.2
+    # via stack-data
 pycodestyle==2.8.0
     # via flake8
 pyflakes==2.4.0
@@ -62,6 +68,8 @@ pygments==2.10.0
     # via ipython
 six==1.16.0
     # via junit-xml
+stack-data==0.2.0
+    # via ipython
 tomli==1.2.1
     # via
     #   black

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 backcall==0.2.0
     # via ipython
-black==21.9b0
+black==22.1.0
     # via -r requirements-dev.in
 click==8.0.1
     # via black
@@ -58,8 +58,6 @@ pyflakes==2.3.1
     # via flake8
 pygments==2.10.0
     # via ipython
-regex==2021.9.30
-    # via black
 six==1.16.0
     # via junit-xml
 toml==0.10.2
@@ -71,9 +69,7 @@ traitlets==5.1.0
     #   ipython
     #   matplotlib-inline
 typing-extensions==3.10.0.2
-    # via
-    #   black
-    #   mypy
+    # via mypy
 unittest-xml-reporting==3.0.4
     # via -r requirements-dev.in
 wcwidth==0.2.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,6 +28,8 @@ jedi==0.18.0
     # via ipython
 junit-xml==1.9
     # via flake8-formatter-junit-xml
+lxml==4.7.1
+    # via unittest-xml-reporting
 matplotlib-inline==0.1.3
     # via ipython
 mccabe==0.6.1
@@ -70,7 +72,7 @@ traitlets==5.1.0
     #   matplotlib-inline
 typing-extensions==3.10.0.2
     # via mypy
-unittest-xml-reporting==3.0.4
+unittest-xml-reporting==3.2.0
     # via -r requirements-dev.in
 wcwidth==0.2.5
     # via prompt-toolkit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,7 +34,7 @@ matplotlib-inline==0.1.3
     # via ipython
 mccabe==0.6.1
     # via flake8
-mypy==0.910
+mypy==0.931
     # via -r requirements-dev.in
 mypy-extensions==0.4.3
     # via
@@ -62,10 +62,10 @@ pygments==2.10.0
     # via ipython
 six==1.16.0
     # via junit-xml
-toml==0.10.2
-    # via mypy
 tomli==1.2.1
-    # via black
+    # via
+    #   black
+    #   mypy
 traitlets==5.1.0
     # via
     #   ipython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ flake8-formatter-junit-xml==0.0.6
     # via -r requirements-dev.in
 ipython==7.31.1
     # via -r requirements-dev.in
-isort==5.8.0
+isort==5.10.1
     # via -r requirements-dev.in
 jedi==0.18.0
     # via ipython

--- a/requirements.in
+++ b/requirements.in
@@ -5,4 +5,4 @@
 # Note: To install a package from a Git VCS repository, see the following example:
 #   git+https://github.com/example/example.git@example-vcs-ref#egg=example-pkg[foo,bar]==1.42.3
 
-djangorestframework==3.12.4
+djangorestframework==3.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.4.1
     # via django
-django==3.2.8
+django==3.2.11
     # via djangorestframework
 djangorestframework==3.12.4
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.4.1
     # via django
-django==3.2.12
+django==3.2.13
     # via djangorestframework
 djangorestframework==3.13.1
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.4.1
     # via django
-django==3.2.11
+django==3.2.12
     # via djangorestframework
 djangorestframework==3.13.1
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,11 @@ asgiref==3.4.1
     # via django
 django==3.2.11
     # via djangorestframework
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via -r requirements.in
 pytz==2021.3
-    # via django
+    # via
+    #   django
+    #   djangorestframework
 sqlparse==0.4.2
     # via django

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@
 
 [metadata]
 name = fyntex-drf-pagination-utils
-version = 1.0.1
+version = 1.1.0
 description =
   A library that provides custom pagination styles and pagination-related
   utilities for Django REST Framework.


### PR DESCRIPTION
- (PR #19, 2022-01-24) chore(deps-dev): Bump ipython from 7.28.0 to 7.31.1
- (PR #21, 2022-01-24) chore(deps): Bump django from 3.2.8 to 3.2.11
- (PR #22, 2022-02-03) chore: Add Dependabot configuration
- (PR #26, 2022-02-03) chore: bump black from 21.9b0 to 22.1.0
- (PR #25, 2022-02-03) chore: bump djangorestframework from 3.12.4 to 3.13.1
- (PR #27, 2022-02-03) chore: bump unittest-xml-reporting from 3.0.4 to 3.2.0
- (PR #23, 2022-02-03) chore: bump isort from 5.8.0 to 5.10.1
- (PR #30, 2022-02-03) chore: bump flake8 from 3.9.2 to 4.0.1
- (PR #29, 2022-02-03) chore: bump mypy from 0.910 to 0.931
- (PR #31, 2022-03-24) chore: bump django from 3.2.11 to 3.2.12
- (PR #32, 2022-03-24) chore: bump coverage from 6.0 to 6.3.2
- (PR #37, 2022-03-24) chore: bump mypy from 0.931 to 0.942
- (PR #41, 2022-05-04) chore: bump django from 3.2.12 to 3.2.13
- (PR #39, 2022-05-04) chore: bump black from 22.1.0 to 22.3.0
- (PR #42, 2022-05-05) chore: bump mypy from 0.942 to 0.950
- (PR #40, 2022-05-06) feat: Add pagination data to response schema
- (PR #43, 2022-05-06) chore: bump ipython from 7.31.1 to 8.3.0